### PR TITLE
[PR] Add custom featured image handling to use larger size

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -18,3 +18,11 @@ function wsu_medicine_sharing_footer() {
 		});
 	</script><?php
 }
+
+add_action( 'after_setup_theme', 'wsu_medicine_setup_image_sizes', 10 );
+/**
+ * Add an image size for a width of 1600 for larger featured images.
+ */
+function wsu_medicine_setup_image_sizes() {
+	$test = add_image_size( 'medicine-featured-image', 1600, 99164 );
+}

--- a/parts/featured-images.php
+++ b/parts/featured-images.php
@@ -1,0 +1,18 @@
+<?php
+
+// If a featured image is assigned to the post, display as a background image.
+
+if ( spine_has_background_image() ) {
+	$background_image_src = spine_get_background_image_src();
+	?>
+
+	<style> html { background-image: url(<?php echo esc_url( $background_image_src ); ?>); }</style>
+
+<?php } ?>
+
+<?php if ( spine_has_featured_image() ) {
+	$featured_image_src = spine_get_featured_image_src( 'medicine-featured-image' ); ?>
+	<figure class="featured-image" style="background-image: url('<?php echo $featured_image_src ?>');">
+		<?php spine_the_featured_image( 'medicine-featured-image' ); ?>
+	</figure>
+<?php } ?>


### PR DESCRIPTION
We should add a filter upstream to allow a theme to easily override
the default size for a featured image. As we're on a shorter
timeline, it makes sense to override the featured-images.php
template and add our own.

Provides for a 1600 x anything image
